### PR TITLE
Rename ATAC to ATC

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,7 +1,7 @@
 # RESPONSIBILITIES
 
 ## TERMS OF REFERENCE
-- Flag proposals within the Wallet Council as “ready” (or not) to be voted by ATAC.
+- Flag proposals within the Wallet Council as “ready” (or not) to be voted by ATC.
 - Create a voting record on the agreed best practices, standards, features for Algorand
 applications and wallets, with decisions recorded on GitHub and the Algorand Wallet
 Compatibility Matrix.
@@ -14,10 +14,10 @@ frame.
 - Cast votes within the specified voting window whether that’s during the meeting or
 offline (e.g. via email).
 - Propose agenda items.
-- Attend ATAC and Wallet Council meetings.
+- Attend ATC and Wallet Council meetings.
     - If you cannot attend, you should elect a representative to participate and handle
 communications.
-    - Attendance is flexible, however fellow ATAC members may vote to remove you
+    - Attendance is flexible, however fellow ATC members may vote to remove you
 for consistent absence.
 
 # VOTING
@@ -38,12 +38,12 @@ a "No Opinion" vote, when the voting window closes.
 - Votes are to be cast during meetings but can also be
 submitted offline, such as via email for those who were not
 able to attend.
-- All ATAC votes are public.
+- All ATC votes are public.
 
 ## Voting options
 - **Hold** - Committee is aware of proposal.
 Nothing is suggested to be done at present.
-- **Assess** - Some or all of the ATAC members will
+- **Assess** - Some or all of the ATC members will
 give the proposal serious assessment.
 - **Trial** - Proposal is ready for trial and already
 has reference implementations.

--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -1,4 +1,4 @@
-# Algorand Technical Adoption Committee Members
+# Algorand Technical Committee Members
 
 ## Algorand Foundation
 - Representative: [Bruno Martins](bruno.martins@algorand.foundation)

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ The radar is divided into four quadrants, each representing a different level of
 
 ## Updates
 
-The radar is reviewed monthly by the ATAC (Algorand Technical Adoption Comittee). Items in the radar are reviewed and moved to different quadrants as needed. 
+The radar is reviewed monthly by the ATC (Algorand Technical Comittee). Items in the radar are reviewed and moved to different quadrants as needed.
 
-Items being moved from **HOLD** to other quadrants are done so by voting by the ATAC's members. 
+Items being moved from **HOLD** to other quadrants are done so by voting by the ATC's members.
 
-The group will accept pull requests to add new items to the radar. New items will be added to the **HOLD** quadrant and will be reviewed by the ATAC in the next monthly meeting.
+The group will accept pull requests to add new items to the radar. New items will be added to the **HOLD** quadrant and will be reviewed by the ATC in the next monthly meeting.
 
 ## How to add a new item
 
-To add a new item to the radar, please create a pull request where you add a new entry to the config.json file. The entry should be in the following format: 
+To add a new item to the radar, please create a pull request where you add a new entry to the config.json file. The entry should be in the following format:
 
 ```json
     {


### PR DESCRIPTION
Change the name from "Algorand Technical Adoption Committee (ATAC)" to "Algorand Technical Committee (ATC)".